### PR TITLE
fix double important SoundModule

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -3,19 +3,15 @@ import { NgModule } from '@angular/core';
 
 import { AppComponent } from './app.component';
 import { AppRoutingModule } from './app-routing.module';
-import { SoundModule } from './sound/sound.module';
 
 
 @NgModule({
   declarations: [
     AppComponent,
-
   ],
   imports: [
     BrowserModule,
     AppRoutingModule,
-    SoundModule,
-    
   ],
   providers: [],
   bootstrap: [AppComponent]


### PR DESCRIPTION
you can only import it lazy loaded from app-routing or normally from app.module but you can't import it from both